### PR TITLE
Use display prices setting for shipping and summary in documents

### DIFF
--- a/changelog/_unreleased/2021-01-19-use-display-prices-settings-for-shipping-and-summary-in-documents.md
+++ b/changelog/_unreleased/2021-01-19-use-display-prices-settings-for-shipping-and-summary-in-documents.md
@@ -1,0 +1,10 @@
+---
+title:              Use display prices setting for shipping and summary in documents
+issue:              
+author:             Lars Schröder
+author_email:       lars.schroeder@kielcoding.de
+author_github:      @larsbo
+---
+# Core
+*  Add new block `document_line_item_table_shipping_prices` in document template `Framework/Resources/views/documents/base.html.twig` 
+*  Add check for `config.displayPrices` in document template `Framework/Resources/views/documents/base.html.twig` for order shipping positions and summary table


### PR DESCRIPTION
### 1. Why is this change necessary?
If you disable the setting "display prices" in the document template the prices and tax details of shipping entries and also the summery are still visible on the document.

### 2. What does this change do, exactly?
Add a check for the displayPrices setting to the shipping entries and the sum block.

### 3. Describe each step to reproduce the issue or behaviour.
Generate a delivery note that contains a shipping position.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
